### PR TITLE
Use collection-2021-1.0 conda env for tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ resources:
     - repository: templates
       type: github
       name: NSLS-II/profile-collection-ci
-      ref: refs/heads/collection-2020-2.0rc9
+      ref: refs/heads/collection-2021-1.0
       endpoint: github
 
 jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,4 +9,4 @@ resources:
 jobs:
 - template: azure-linux.yml@templates  # Template reference
   parameters:
-    beamline_acronym: JPLS
+      beamline_acronym: JPLS  # TODO: rename to OPLS once the nslsii.configure_base(...) is updated.


### PR DESCRIPTION
Here is the update to run against the `collection-2021-1.0` conda environment.

Expected outcomes:
- failed test with the latest jedi v0.18
- after https://github.com/NSLS-II/profile-collection-ci/pull/16 is updated to disable jedi (i.e., with the `--IPCompleter.use_jedi=False` option, see https://github.com/NSLS-II/playbooks/pull/411), we should see the successful test.