### PR TITLE
HACK: adjust read and wirte timeouts to a minute

### DIFF
--- a/startup/00-startup.py
+++ b/startup/00-startup.py
@@ -12,8 +12,8 @@ from event_model import RunRouter
 import event_model
 from pathlib import Path
 
-EpicsSignal.set_defaults(connection_timeout=10)
-EpicsSignalRO.set_defaults(connection_timeout=10)
+EpicsSignal.set_defaults(connection_timeout=10, timeout=60, write_timeout=60)
+EpicsSignalRO.set_defaults(connection_timeout=10, timeout=60)
 
 configure_base(
     get_ipython().user_ns, 


### PR DESCRIPTION
This attempts to paper over long (5s+) hangs when setting the acquire time on
Lambda detectors.