### PR TITLE
Redis Upgrade

### DIFF
--- a/startup/00-startup.py
+++ b/startup/00-startup.py
@@ -44,11 +44,13 @@ class TiledInserter:
 tiled_inserter = TiledInserter()
 
 configure_base(
-    get_ipython().user_ns,
-    broker_name=tiled_inserter,
-    publish_documents_with_kafka=True,
-    redis_url = "info.smi.nsls2.bnl.gov",
-    redis_prefix = "opls-")
+	    get_ipython().user_ns,
+	    broker_name=tiled_inserter,
+	    publish_documents_with_kafka=True,
+	    redis_url = "xf12id1-opls-redis1.nsls2.bnl.gov",
+	    redis_port=6380,
+	    redis_ssl=True,
+)
 
 print("\nInitializing Tiled reading client...\nMake sure you check for duo push.")
 tiled_reading_client = from_profile("nsls2", username=None)["opls"]["raw"]


### PR DESCRIPTION
This PR upgrades configure base to use thew new secure redis. The pixi upgrade has already been done. Steps:

- [ ] Run BSUI and check RE.md 
- [ ] In the BSUI session transfer over the old metadata to the new redis
```
import redis
from redis_json_dict import RedisJSONDict
old_md = RE.md
with open("/etc/bluesky/redis.secret") as f:
     secret = f.read().strip()
new_redis_client = redis.Redis("xf12id1-opls-redis1.nsls2.bnl.gov", port=6380, ssl=True, password=secret)
new_md = RedisJSONDict(new_redis_client, prefix="")
for k,v in dict(old_md).items():
    new_md[k]=v
```
- [ ] Confirm RE.md is accurate
- [ ] Pull this PR and restart BSUI
- [ ] check RE.md is connected to the correct client using `RE.md._redis_client_`
- [ ] Run acceptance tests with Honghu & Ben

also #22  should also be merged but I realized too late it was there..